### PR TITLE
Hotfix

### DIFF
--- a/src/main/java/edition/academy/seventh/connector/ConnectorProvider.java
+++ b/src/main/java/edition/academy/seventh/connector/ConnectorProvider.java
@@ -13,7 +13,8 @@ public interface ConnectorProvider {
 
   /**
    * Closes {@link javax.persistence.EntityManagerFactory} and all provided {@link
-   * javax.persistence.EntityManager entity managers}.
+   * javax.persistence.EntityManager entity managers} if {@link EntityConnector entity connector}
+   * has parameter connectorProviderShouldBeClosed set as true.
    */
   void close();
 }

--- a/src/main/java/edition/academy/seventh/connector/EntityConnector.java
+++ b/src/main/java/edition/academy/seventh/connector/EntityConnector.java
@@ -18,9 +18,11 @@ abstract class EntityConnector implements ConnectorProvider {
   private static final Logger logger = LoggerFactory.getLogger(EntityConnector.class);
   private final String persistenceUnitName;
   private EntityManagerFactory entityManagerFactory;
+  private boolean connectorProviderShouldBeClosed;
 
-  EntityConnector(final String persistenceUnitName) {
+  EntityConnector(final String persistenceUnitName, final boolean connectorProviderShouldBeClosed) {
     this.persistenceUnitName = persistenceUnitName;
+    this.connectorProviderShouldBeClosed = connectorProviderShouldBeClosed;
   }
 
   /**
@@ -39,7 +41,7 @@ abstract class EntityConnector implements ConnectorProvider {
    */
   @Override
   public final void close() {
-    if (entityManagerFactory.isOpen()) {
+    if (entityManagerFactory.isOpen() && connectorProviderShouldBeClosed) {
       entityManagerFactory.close();
       logger.info("EntityManagerFactory has been closed");
     }

--- a/src/main/java/edition/academy/seventh/connector/H2Connector.java
+++ b/src/main/java/edition/academy/seventh/connector/H2Connector.java
@@ -6,7 +6,7 @@ import java.util.Map;
 /** @author Kamil Rojek */
 class H2Connector extends EntityConnector {
   H2Connector() {
-    super("H2Unit");
+    super("H2Unit", false);
   }
 
   @Override
@@ -15,7 +15,7 @@ class H2Connector extends EntityConnector {
     settings.put("javax.persistence.jdbc.driver", "org.h2.Driver");
     settings.put("javax.persistence.jdbc.user", "sa");
     settings.put("javax.persistence.jdbc.password", "sa");
-    settings.put("javax.persistence.jdbc.url", "jdbc:h2:tcp://localhost:9092/~/test");
+    settings.put("javax.persistence.jdbc.url", "jdbc:h2:test://localhost:9092/~/test");
     settings.put("hibernate.dialect", "org.hibernate.dialect.H2Dialect");
     settings.put("hibernate.show_sql", "true");
     settings.put("hibernate.hbm2ddl.auto", "create-drop");

--- a/src/main/java/edition/academy/seventh/connector/H2Connector.java
+++ b/src/main/java/edition/academy/seventh/connector/H2Connector.java
@@ -15,7 +15,7 @@ class H2Connector extends EntityConnector {
     settings.put("javax.persistence.jdbc.driver", "org.h2.Driver");
     settings.put("javax.persistence.jdbc.user", "sa");
     settings.put("javax.persistence.jdbc.password", "sa");
-    settings.put("javax.persistence.jdbc.url", "jdbc:h2:test://localhost:9092/~/test");
+    settings.put("javax.persistence.jdbc.url", "jdbc:h2:tcp://localhost:9092/~/test");
     settings.put("hibernate.dialect", "org.hibernate.dialect.H2Dialect");
     settings.put("hibernate.show_sql", "true");
     settings.put("hibernate.hbm2ddl.auto", "create-drop");

--- a/src/main/java/edition/academy/seventh/connector/PostgresConnector.java
+++ b/src/main/java/edition/academy/seventh/connector/PostgresConnector.java
@@ -8,7 +8,7 @@ class PostgresConnector extends EntityConnector {
   private Map<String, String> credentials;
 
   PostgresConnector() {
-    super("PostgreSQLUnit");
+    super("PostgreSQLUnit", true);
     credentials = System.getenv();
   }
 

--- a/src/main/java/edition/academy/seventh/persistence/BookRepository.java
+++ b/src/main/java/edition/academy/seventh/persistence/BookRepository.java
@@ -37,13 +37,11 @@ public class BookRepository {
   private EntityManager entityManager;
   private ConnectorProvider connectorProvider;
   private BookDtoParser bookDtoParser;
-  private boolean shouldCloseConnectorProvider;
 
   @Autowired
   public BookRepository(BookDtoParser bookDtoParser, @Value("${robot.db}") String database) {
     connectorProvider = ConnectorFactory.of(DatabaseType.valueOf(database));
     this.bookDtoParser = bookDtoParser;
-    shouldCloseConnectorProvider = checkIfConnectorProviderShouldBeClosed(database);
   }
 
   public BookstoreBook getBookstoreBookById(Long id) {
@@ -64,7 +62,7 @@ public class BookRepository {
     logger.info("Saving " + bookDtos.size() + " books in database");
     transaction.commit();
     entityManager.close();
-    if (shouldCloseConnectorProvider) connectorProvider.close();
+    connectorProvider.close();
   }
 
   /**
@@ -85,7 +83,7 @@ public class BookRepository {
 
     logger.info("Called getBooksFromDatabase(), returning " + bookstoreBookList.size() + " books");
     entityManager.close();
-    if (shouldCloseConnectorProvider) connectorProvider.close();
+    connectorProvider.close();
 
     return parseBookstoreBooksIntoBookDtos(bookstoreBookList);
   }
@@ -212,9 +210,5 @@ public class BookRepository {
 
   private void addBookToDatabase(BookDto bookDto) {
     bookDtoParser.parseBookDtoIntoModel(bookDto);
-  }
-
-  private boolean checkIfConnectorProviderShouldBeClosed(String database) {
-    return database.equalsIgnoreCase(DatabaseType.POSTGRESQL.name());
   }
 }

--- a/src/main/java/edition/academy/seventh/security/UserRepository.java
+++ b/src/main/java/edition/academy/seventh/security/UserRepository.java
@@ -62,6 +62,7 @@ class UserRepository {
           String.format("Retrieving data from db unsuccessful. Message: %s", message));
     } finally {
       entityManager.close();
+      connectorProvider.close();
     }
   }
 
@@ -91,6 +92,7 @@ class UserRepository {
           String.format("Retrieving data from db unsuccessful. Message: %s", message));
     } finally {
       entityManager.close();
+      connectorProvider.close();
     }
   }
 
@@ -116,6 +118,7 @@ class UserRepository {
       return false;
     } finally {
       entityManager.close();
+      connectorProvider.close();
     }
     return true;
   }

--- a/src/main/java/edition/academy/seventh/security/WebSecurityConfig.java
+++ b/src/main/java/edition/academy/seventh/security/WebSecurityConfig.java
@@ -7,19 +7,12 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import org.springframework.security.web.firewall.FirewalledRequest;
-import org.springframework.security.web.firewall.HttpFirewall;
-import org.springframework.security.web.firewall.RequestRejectedException;
-import org.springframework.security.web.firewall.StrictHttpFirewall;
-
-import javax.servlet.http.HttpServletRequest;
 
 /**
  * Configuration class responsible for user authentication and authorization.


### PR DESCRIPTION

Sprint#6 Naprawa zamykania połączeń z postgreslq

-brak zamykania połączeń do H2 ze względu na ustawienie create-drop
-ustawienie zamykania połączeń w EnitityConnector w zmiennej connectorProviderShouldBeClosed